### PR TITLE
The future and past disabled dates should honour internalDate

### DIFF
--- a/THCalendarDatePicker/THDatePickerViewController.m
+++ b/THCalendarDatePicker/THDatePickerViewController.m
@@ -282,7 +282,7 @@
     if (_autoCloseOnSelectDate)
         return YES;
     float diff = [self.internalDate timeIntervalSinceDate:_dateNoTime];
-    return (self.internalDate && _dateNoTime && diff != 0)
+    return (self.internalDate && _dateNoTime && diff >= 0)
     || (self.internalDate && !_dateNoTime)
     || (!self.internalDate && _dateNoTime);
 }


### PR DESCRIPTION
I am not quite sure what the .date is being used. But it seems that using it in when checking disabled days makes sense. My use-case is having two buttons "select start date" and "select end date" and setting 'internalDate' to start date makes it behave as expected.
