### PR TITLE
preventing the button to wait before closing the modal

### DIFF
--- a/THCalendarDatePicker/THDatePickerViewController.m
+++ b/THCalendarDatePicker/THDatePickerViewController.m
@@ -407,12 +407,8 @@
         if (_autoCloseOnSelectDate) {
             [self setDate:[NSDate date]];
             [self redraw];
-            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-                [self.delegate datePickerDonePressed:self];
-            });
-        } else {
-            [self.delegate datePickerDonePressed:self];
         }
+        [self.delegate datePickerDonePressed:self];
     }
 }
 


### PR DESCRIPTION
If autoCloseOnSelectDate was set, there was an unuseful delay before calling the delegate method of the okbutton. But this small delay allowed to tap several time on it. 
When tapping twice on the ok button, the delegate was called multiple times and KNSemiModalViewController tried to remove itself mutliple times, which crashed. 